### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/dotPath.js
+++ b/lib/dotPath.js
@@ -77,6 +77,7 @@ function pave( object , pathArray ) {
 	for ( i = 0 , iMax = pathArray.length - 1 ; i < iMax ; i ++ ) {
 		key = pathArray[ i ] ;
 
+		if (typeof key !== 'string' && typeof key !== 'number') { key = String(key); }
 		if ( key === '__proto__' || typeof pointer[ key ] === 'function' ) { throw new Error( PROTO_POLLUTION_MESSAGE ) ; }
 		if ( ! pointer[ key ] || typeof pointer[ key ] !== 'object' ) { pointer[ key ] = {} ; }
 


### PR DESCRIPTION
Fix prototype pollution when path components are not strings